### PR TITLE
Use libidn for stringprep

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation 'com.otaliastudios:transcoder:0.9.1'
 
     implementation 'org.jxmpp:jxmpp-jid:1.0.3'
+    implementation 'org.jxmpp:jxmpp-stringprep-libidn:1.0.3'
     implementation 'org.osmdroid:osmdroid-android:6.1.11'
     implementation 'org.hsluv:hsluv:0.2'
     implementation 'org.conscrypt:conscrypt-android:2.5.2'

--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -1144,6 +1144,7 @@ public class XmppConnectionService extends Service {
     @SuppressLint("TrulyRandom")
     @Override
     public void onCreate() {
+        org.jxmpp.stringprep.libidn.LibIdnXmppStringprep.setup();
         if (Compatibility.runsTwentySix()) {
             mNotificationService.initializeChannels();
         }


### PR DESCRIPTION
Which actually validates according to spec instead of just being lazy.

For example, this means an invalid MUC nick will actually be caught by the app and reported in the UI rather than trying to send it to the server and giving and obscure message about "nick already taken".