### PR TITLE
Remove READ_CONTACTS permission from Play Store version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,11 +86,11 @@ ext {
 
 android {
     namespace 'eu.siacs.conversations'
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionCode 42051
         versionName "2.12.2-2"
         archivesBaseName += "-$versionName"

--- a/build.gradle
+++ b/build.gradle
@@ -91,8 +91,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 32
-        versionCode 42050
-        versionName "2.12.2"
+        versionCode 42051
+        versionName "2.12.2-2"
         archivesBaseName += "-$versionName"
         applicationId "org.snikket.android"
         resValue "string", "applicationId", applicationId
@@ -142,10 +142,12 @@ android {
         playstore {
             dimension "distribution"
             versionNameSuffix "+playstore"
+            buildConfigField "boolean", "CONTACTS_INTEGRATION", "false"
         }
         free {
             dimension "distribution"
             versionNameSuffix "+free"
+            buildConfigField "boolean", "CONTACTS_INTEGRATION", "true"
         }
     }
 

--- a/src/conversationsFree/AndroidManifest.xml
+++ b/src/conversationsFree/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+
+</manifest>

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.READ_PROFILE" />
     <uses-permission
         android:name="android.permission.READ_PHONE_STATE"

--- a/src/main/java/eu/siacs/conversations/Config.java
+++ b/src/main/java/eu/siacs/conversations/Config.java
@@ -59,6 +59,10 @@ public final class Config {
 
     public static final long CONTACT_SYNC_RETRY_INTERVAL = 1000L * 60 * 5;
 
+    // 2024-02-14: Contacts integration has been removed from Play Store builds, at least for now,
+    // due to Google aggressively delisting XMPP apps that use it, claiming that the apps are uploading
+    // contact lists to the server (even though they are not).
+    public static final boolean CONTACTS_INTEGRATION = BuildConfig.CONTACTS_INTEGRATION;
 
     public static final boolean QUICKSTART_ENABLED = true;
 

--- a/src/main/java/eu/siacs/conversations/persistance/FileBackend.java
+++ b/src/main/java/eu/siacs/conversations/persistance/FileBackend.java
@@ -143,7 +143,7 @@ public class FileBackend {
                                 "do not consider video file with min width larger than 720 for size check");
                         continue;
                     }
-                } catch (NotAVideoFile notAVideoFile) {
+                } catch (final IOException | NotAVideoFile e) {
                     // ignore and fall through
                 }
             }
@@ -268,7 +268,7 @@ public class FileBackend {
         return inSampleSize;
     }
 
-    private static Dimensions getVideoDimensions(Context context, Uri uri) throws NotAVideoFile {
+    private static Dimensions getVideoDimensions(Context context, Uri uri) throws NotAVideoFile, IOException {
         MediaMetadataRetriever mediaMetadataRetriever = new MediaMetadataRetriever();
         try {
             mediaMetadataRetriever.setDataSource(context, uri);
@@ -294,7 +294,7 @@ public class FileBackend {
     }
 
     private static Dimensions getVideoDimensions(MediaMetadataRetriever metadataRetriever)
-            throws NotAVideoFile {
+            throws NotAVideoFile, IOException {
         String hasVideo =
                 metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_HAS_VIDEO);
         if (hasVideo == null) {
@@ -1527,7 +1527,7 @@ public class FileBackend {
                         Log.d(Config.LOGTAG, "ambiguous file " + mime + " is audio");
                         body.append("|0|0|").append(getMediaRuntime(file));
                     }
-                } catch (final NotAVideoFile e) {
+                } catch (final IOException | NotAVideoFile e) {
                     Log.d(Config.LOGTAG, "ambiguous file " + mime + " is audio");
                     body.append("|0|0|").append(getMediaRuntime(file));
                 }
@@ -1547,7 +1547,7 @@ public class FileBackend {
                                 .append('|')
                                 .append(dimensions.height);
                     }
-                } catch (NotAVideoFile notAVideoFile) {
+                } catch (final IOException | NotAVideoFile notAVideoFile) {
                     Log.d(
                             Config.LOGTAG,
                             "file with mime type " + file.getMimeType() + " was not a video file");
@@ -1592,7 +1592,7 @@ public class FileBackend {
         return new Dimensions(imageHeight, imageWidth);
     }
 
-    private Dimensions getVideoDimensions(File file) throws NotAVideoFile {
+    private Dimensions getVideoDimensions(final File file) throws NotAVideoFile, IOException {
         MediaMetadataRetriever metadataRetriever = new MediaMetadataRetriever();
         try {
             metadataRetriever.setDataSource(file.getAbsolutePath());

--- a/src/main/java/eu/siacs/conversations/ui/ContactDetailsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ContactDetailsActivity.java
@@ -119,7 +119,7 @@ public class ContactDetailsActivity extends OmemoActivity implements OnAccountUp
     private void checkContactPermissionAndShowAddDialog() {
         if (hasContactsPermission()) {
             showAddToPhoneBookDialog();
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        } else if (Config.CONTACTS_INTEGRATION && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             requestPermissions(new String[]{Manifest.permission.READ_CONTACTS}, REQUEST_SYNC_CONTACTS);
         }
     }


### PR DESCRIPTION
Google has been flagging all XMPP apps with this permission, claiming that
they upload users' contacts to a third-party without properly disclosing such.

The reality is that the contacts integration is actually entirely local, and
allows you to (optionally) link your XMPP contacts with entries in your phone
contacts, so you can see your preferred contact photo, etc.

As nice a little feature as this is, it's probably not widely used, and it's
not worth having Google de-list the app entirely due to it.