### PR TITLE
Allow edits from carbons

### DIFF
--- a/src/main/java/eu/siacs/conversations/entities/Conversation.java
+++ b/src/main/java/eu/siacs/conversations/entities/Conversation.java
@@ -413,8 +413,7 @@ public class Conversation extends AbstractEntity
                     continue;
                 }
                 if (mcp.equals(counterpart)
-                        && ((message.getStatus() == Message.STATUS_RECEIVED) == received)
-                        && (carbon == message.isCarbon() || received)) {
+                        && ((message.getStatus() == Message.STATUS_RECEIVED) == received)) {
                     if (id.equals(message.getRemoteMsgId())
                             && !message.isFileOrImage()
                             && !message.treatAsDownloadable()) {


### PR DESCRIPTION
Allow other resources of the same user to edit their own outgoing messages.