### PR TITLE
Add audio message playback speed control (1×/1.25×/1.5×/2×)

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/service/AudioPlayer.java
+++ b/src/main/java/eu/siacs/conversations/ui/service/AudioPlayer.java
@@ -43,8 +43,10 @@ public class AudioPlayer
 
     private static final int REFRESH_INTERVAL = 250;
     private static final Object LOCK = new Object();
+    private static final float[] SPEED_STEPS = {1.0f, 1.25f, 1.5f, 2.0f};
     private static MediaPlayer player = null;
     private static Message currentlyPlayingMessage = null;
+    private static int currentSpeedIndex = 0;
     private static PowerManager.WakeLock wakeLock;
     private final MessageAdapter messageAdapter;
     private final WeakReferenceSet<RelativeLayout> audioPlayerLayouts = new WeakReferenceSet<>();
@@ -118,6 +120,8 @@ public class AudioPlayer
         viewHolder.progress.setThumbTintList(color);
         viewHolder.progress.setProgressTintList(color);
         viewHolder.playPause.setOnClickListener(this);
+        viewHolder.playbackSpeed.setOnClickListener(this);
+        updateSpeedButton(viewHolder);
         final Context context = viewHolder.playPause.getContext();
         if (message == currentlyPlayingMessage) {
             if (AudioPlayer.player != null && AudioPlayer.player.isPlaying()) {
@@ -145,6 +149,10 @@ public class AudioPlayer
         if (v.getId() == R.id.play_pause) {
             synchronized (LOCK) {
                 startStop((MaterialButton) v);
+            }
+        } else if (v.getId() == R.id.playback_speed) {
+            synchronized (LOCK) {
+                cycleSpeed();
             }
         }
     }
@@ -411,6 +419,7 @@ public class AudioPlayer
                                 currentlyPlayingMessage,
                                 streamType == AudioManager.STREAM_VOICE_CALL,
                                 progress);
+                        applySpeed();
                     }
                 } catch (Exception e) {
                     Log.w(Config.LOGTAG, e);
@@ -439,6 +448,37 @@ public class AudioPlayer
         messageAdapter.setVolumeControl(AudioManager.STREAM_MUSIC);
     }
 
+    private void cycleSpeed() {
+        currentSpeedIndex = (currentSpeedIndex + 1) % SPEED_STEPS.length;
+        applySpeed();
+        for (WeakReference<RelativeLayout> audioPlayer : audioPlayerLayouts) {
+            final RelativeLayout layout = audioPlayer.get();
+            if (layout != null) {
+                updateSpeedButton(ViewHolder.get(layout));
+            }
+        }
+    }
+
+    private void applySpeed() {
+        if (player != null && player.isPlaying()) {
+            player.setPlaybackParams(
+                    player.getPlaybackParams()
+                            .setSpeed(SPEED_STEPS[currentSpeedIndex])
+                            .setPitch(1.0f));
+        }
+    }
+
+    private void updateSpeedButton(final ViewHolder viewHolder) {
+        if (viewHolder.playbackSpeed == null) {
+            return;
+        }
+        final Context context = viewHolder.playbackSpeed.getContext();
+        final int[] labelRes = {
+            R.string.speed_1x, R.string.speed_1_25x, R.string.speed_1_5x, R.string.speed_2x
+        };
+        viewHolder.playbackSpeed.setText(context.getString(labelRes[currentSpeedIndex]));
+    }
+
     private ViewHolder getCurrentViewHolder() {
         for (WeakReference<RelativeLayout> audioPlayer : audioPlayerLayouts) {
             final Message message = (Message) audioPlayer.get().getTag();
@@ -453,6 +493,7 @@ public class AudioPlayer
         private TextView runtime;
         private SeekBar progress;
         private MaterialButton playPause;
+        private MaterialButton playbackSpeed;
         private MessageAdapter.BubbleColor bubbleColor = MessageAdapter.BubbleColor.SURFACE;
 
         public static ViewHolder get(final RelativeLayout audioPlayer) {
@@ -465,6 +506,7 @@ public class AudioPlayer
             viewHolder.runtime = audioPlayer.findViewById(R.id.runtime);
             viewHolder.progress = audioPlayer.findViewById(R.id.progress);
             viewHolder.playPause = audioPlayer.findViewById(R.id.play_pause);
+            viewHolder.playbackSpeed = audioPlayer.findViewById(R.id.playback_speed);
             audioPlayer.setTag(R.id.TAG_AUDIO_PLAYER_VIEW_HOLDER, viewHolder);
             return viewHolder;
         }

--- a/src/main/res/drawable/ic_speed_24dp.xml
+++ b/src/main/res/drawable/ic_speed_24dp.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20.38,8.57l-1.23,1.85a8,8 0,0 1,-0.22 7.58L5.07,18A8,8 0,0 1,15.58 5.03l1.85,-1.23A10,10 0,0 0,3.35 19a2,2 0,0 0,1.72 1h13.85a2,2 0,0 0,1.74 -1,10 10,0 0,0 -0.27,-10.44z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10.59,15.41a2,2 0,0 0,2.83 0l5.66,-8.49 -8.49,5.66a2,2 0,0 0,0 2.83z" />
+</vector>

--- a/src/main/res/layout/item_message_content.xml
+++ b/src/main/res/layout/item_message_content.xml
@@ -63,12 +63,25 @@
                 app:icon="@drawable/ic_play_arrow_24dp"
                 app:iconSize="26dp" />
 
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/playback_speed"
+                style="?attr/materialIconButtonOutlinedStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:contentDescription="@string/playback_speed"
+                android:text="@string/speed_1x"
+                android:textSize="12sp"
+                app:iconSize="0dp" />
+
             <TextView
                 android:id="@+id/runtime"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_marginEnd="16dp"
+                android:layout_toStartOf="@+id/playback_speed"
+                android:layout_alignTop="@+id/playback_speed"
+                android:layout_marginEnd="4dp"
                 android:layout_marginBottom="16dp"
                 android:textAppearance="?textAppearanceBodySmall" />
 
@@ -79,6 +92,7 @@
                 android:layout_below="@+id/runtime"
                 android:layout_centerVertical="true"
                 android:layout_toEndOf="@+id/play_pause"
+                android:layout_toStartOf="@+id/playback_speed"
                 android:progress="100" />
         </RelativeLayout>
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -991,6 +991,11 @@
     <string name="record_voice_mail">Record voice mail</string>
     <string name="play_audio">Play audio</string>
     <string name="pause_audio">Pause audio</string>
+    <string name="speed_1x">1×</string>
+    <string name="speed_1_25x">1.25×</string>
+    <string name="speed_1_5x">1.5×</string>
+    <string name="speed_2x">2×</string>
+    <string name="playback_speed">Playback speed</string>
     <string name="add_contact_or_create_or_join_group_chat">Add contact, create or join group chat, or discover channels</string>
     <plurals name="view_users">
         <item quantity="one">View %1$d Participant</item>


### PR DESCRIPTION
Adds a speed toggle button to the audio message player that cycles through 1×, 1.25×, 1.5×, and 2× playback speeds. 

Speed persists across messages in the same session and is preserved when the player switches between earpiece and speaker output.